### PR TITLE
[0.6.x] Add option to match pen speed in Relative Mode

### DIFF
--- a/OTD.EnhancedOutputMode.Lib/Tools/TouchSettings.cs
+++ b/OTD.EnhancedOutputMode.Lib/Tools/TouchSettings.cs
@@ -61,6 +61,12 @@ namespace OTD.EnhancedOutputMode.Lib.Tools
 
         public TimeSpan PenResetTimeSpan => penResetTime;
 
+        [BooleanProperty("Match Pen Sensibility in Relative Mode", ""),
+         DefaultPropertyValue(false),
+         ToolTip("OTD.EnhancedOutputMode:\n\n" +
+                 "When Enabled, the touch sensitivity will match to the sensitivity of the pen in Relative output mode.")]
+        public bool MatchPenSensibilityInRelativeMode { get; set; }
+
         [Property("Max X"),
          DefaultPropertyValue(4095),
          ToolTip("OTD.EnhancedOutputMode:\n\n" +

--- a/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
+++ b/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
@@ -19,11 +19,14 @@ namespace OTD.EnhancedOutputMode.Output
     public class EnhancedRelativeOutputMode : RelativeOutputMode, IPointerProvider<IRelativePointer>
     {
         private readonly ITabletReport _convertedReport = new TouchConvertedReport();
+        private readonly HPETDeltaStopwatch _touchStopwatch = new(true);
         private readonly HPETDeltaStopwatch _penStopwatch = new(true);
         private TouchSettings _touchSettings = TouchSettings.Default;
         private bool _initialized = false;
         private bool skipReport = false;
         private int _lastTouchID = -1;
+        private Vector2? _lastTransformedTouchPos;
+        private Vector2? _lastTransformedAbsolutePos;
         private Vector2 _lastPos;
 
         public Matrix3x2 TouchTransformationMatrix { get; protected set; }
@@ -58,7 +61,21 @@ namespace OTD.EnhancedOutputMode.Output
 
             TouchTransformationMatrix = TransformationMatrix;
 
+            if (TouchSettings.MatchPenSensibilityInRelativeMode)
+                UpdateTouchTransformMatrix();
+
             _initialized = true;
+        }
+
+        private void UpdateTouchTransformMatrix()
+        {
+            // Pen & Touch digitizer suffer from a difference in resolution, 
+            // resulting in different speeds for the same sensitivity.
+            var XMultiplier = Tablet.Properties.Specifications.Digitizer.MaxX / TouchSettings.MaxX;
+            var YMultiplier = Tablet.Properties.Specifications.Digitizer.MaxY / TouchSettings.MaxY;
+
+            // This should achieve about the same speed as the pen
+            TouchTransformationMatrix = TransformationMatrix * Matrix3x2.CreateScale(XMultiplier, YMultiplier);
         }
 
         #endregion
@@ -89,6 +106,7 @@ namespace OTD.EnhancedOutputMode.Output
                 if (_lastTouchID != TouchConvertedReport.CurrentFirstTouchID && TouchConvertedReport.CurrentFirstTouchID != -1)
                 {
                     _lastPos = _convertedReport.Position;
+                    _lastTransformedTouchPos = null;
                     skipReport = true;
                 }
 
@@ -99,14 +117,29 @@ namespace OTD.EnhancedOutputMode.Output
                     base.Read(_convertedReport); // We send another report instead of overwriting the touch report since plugins might rely on it
                 else
                     skipReport = false;
-
-                _lastPos = _convertedReport.Position;
             }
             else if (deviceReport is IAbsolutePositionReport) // Restart the pen stopwatch when a pen report is received
                 if (_touchSettings.DisableWhenPenInRange)
                     _penStopwatch.Restart();
 
             base.Read(deviceReport);
+        }
+
+        protected override IAbsolutePositionReport Transform(IAbsolutePositionReport report)
+        {
+            if (report is not TouchConvertedReport)
+                return base.Transform(report);
+
+            Vector2 pos = report.Position;
+            Vector2? delta;
+
+            pos = Vector2.Transform(pos, TouchTransformationMatrix);
+            delta = pos - _lastTransformedTouchPos;
+            _lastTransformedTouchPos = pos;
+
+            report.Position = delta.GetValueOrDefault();
+
+            return report;
         }
 
         protected override void OnOutput(IDeviceReport report)

--- a/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
+++ b/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
@@ -130,11 +130,8 @@ namespace OTD.EnhancedOutputMode.Output
             if (report is not TouchConvertedReport)
                 return base.Transform(report);
 
-            Vector2 pos = report.Position;
-            Vector2? delta;
-
-            pos = Vector2.Transform(pos, TouchTransformationMatrix);
-            delta = pos - _lastTransformedTouchPos;
+            var pos = Vector2.Transform(report.Position, TouchTransformationMatrix);
+            var delta = pos - _lastTransformedTouchPos;
             _lastTransformedTouchPos = pos;
 
             report.Position = delta.GetValueOrDefault();

--- a/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
+++ b/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
@@ -39,7 +39,11 @@ namespace OTD.EnhancedOutputMode.Output
 
         public IList<IAuxFilter> AuxFilters { get; set; } = Array.Empty<IAuxFilter>();
 
-        public TouchSettings TouchSettings { get; private set; } = TouchSettings.Default;
+        public TouchSettings TouchSettings
+        {
+            get => _touchSettings;
+            set => _touchSettings = value ?? TouchSettings.Default;
+        }
 
         #region Initialization
 
@@ -48,7 +52,7 @@ namespace OTD.EnhancedOutputMode.Output
             if (Elements == null)
                 return;
 
-            _touchSettings = Elements.OfType<TouchSettings>().FirstOrDefault() ?? TouchSettings.Default;
+            TouchSettings = Elements.OfType<TouchSettings>().FirstOrDefault() ?? TouchSettings.Default;
 
             // Gather custom filters
             // TODO: someone replace this system with the IPositionedPipelineElement bullshit somehow
@@ -60,7 +64,7 @@ namespace OTD.EnhancedOutputMode.Output
 
             TouchTransformationMatrix = TransformationMatrix;
 
-            if (TouchSettings.MatchPenSensibilityInRelativeMode)
+            if (_touchSettings.MatchPenSensibilityInRelativeMode)
                 UpdateTouchTransformMatrix();
 
             _initialized = true;
@@ -70,8 +74,8 @@ namespace OTD.EnhancedOutputMode.Output
         {
             // Pen & Touch digitizer suffer from a difference in resolution, 
             // resulting in different speeds for the same sensitivity.
-            var XMultiplier = Tablet.Properties.Specifications.Digitizer.MaxX / TouchSettings.MaxX;
-            var YMultiplier = Tablet.Properties.Specifications.Digitizer.MaxY / TouchSettings.MaxY;
+            var XMultiplier = Tablet.Properties.Specifications.Digitizer.MaxX / _touchSettings.MaxX;
+            var YMultiplier = Tablet.Properties.Specifications.Digitizer.MaxY / _touchSettings.MaxY;
 
             // This should achieve about the same speed as the pen
             TouchTransformationMatrix = TransformationMatrix * Matrix3x2.CreateScale(XMultiplier, YMultiplier);

--- a/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
+++ b/OTD.EnhancedOutputMode/Output/EnhancedRelativeOutputMode.cs
@@ -26,7 +26,6 @@ namespace OTD.EnhancedOutputMode.Output
         private bool skipReport = false;
         private int _lastTouchID = -1;
         private Vector2? _lastTransformedTouchPos;
-        private Vector2? _lastTransformedAbsolutePos;
         private Vector2 _lastPos;
 
         public Matrix3x2 TouchTransformationMatrix { get; protected set; }


### PR DESCRIPTION
Add an option for the motion of touch input to match pen inputs.

New settings while be available in `Touch Settings` under `Match Pen Sensibility in Relative Mode`.
New behavior may be ignoring Reset Time.